### PR TITLE
modified to use es6 imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "server/app.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "serve": "vue-cli-service serve",

--- a/server/app.js
+++ b/server/app.js
@@ -1,9 +1,9 @@
-const express = require('express')
-const serveStatic =  require('serve-static')
-const path = require('path')
-// import express from 'express'
-// import serveStatic from 'serve-static'
-// import path from 'path'
+// const express = require('express')
+// const serveStatic =  require('serve-static')
+// const path = require('path')
+import express from 'express'
+import serveStatic from 'serve-static'
+import path from 'path'
 
 const app = express()
 app.use(serveStatic(path.join(path.resolve(), 'client/dist')))

--- a/vue.config.mjs
+++ b/vue.config.mjs
@@ -1,7 +1,7 @@
 // vue.config.(js -> mjs)
 
-// import { join, resolve } from 'path'
-const { join, resolve } = require('path') 
+import { join, resolve } from 'path'
+// const { join, resolve } = require('path') 
 
 const path = p => join(resolve(), p)
 


### PR DESCRIPTION
`npm run build` throws with

```
This relative module was not found:

* ./src/main.js in multi ./src/main.js
```